### PR TITLE
removed [AUTHORIZE] from the Controllers since the SCOPES are associa…

### DIFF
--- a/Controllers/ImagesController.cs
+++ b/Controllers/ImagesController.cs
@@ -18,7 +18,7 @@ namespace BackSide.Controllers
     [Route("api/[controller]")]
     [ApiController]
     // MLS 10/16/23 Temporarily remove call to this
-    [Authorize]
+    //[Authorize]
     public class ImagesController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/ItemsController.cs
+++ b/Controllers/ItemsController.cs
@@ -19,7 +19,7 @@ namespace BackSide.Controllers
     [Route("api/[controller]")]
     [ApiController]
     // MLS 10/16/23 Temporarily remove call to this
-    [Authorize]
+    //[Authorize]
     public class ItemsController : ControllerBase
     {
         private readonly ApplicationDbContext _context;


### PR DESCRIPTION
…ted with the on-premise api/client_ID/READ, api/client_ID/READWRITE. Client_ID is only used when the application is NOT running in Azure and is on-premise.