### PR TITLE
1) #defined Use_Azure_Blob_Storage in source files which use it.

### DIFF
--- a/Controllers/ImagesController.cs
+++ b/Controllers/ImagesController.cs
@@ -18,7 +18,7 @@ namespace BackSide.Controllers
     [Route("api/[controller]")]
     [ApiController]
     // MLS 10/16/23 Temporarily remove call to this
-    //[Authorize]
+    [Authorize]
     public class ImagesController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/ItemsController.cs
+++ b/Controllers/ItemsController.cs
@@ -19,7 +19,7 @@ namespace BackSide.Controllers
     [Route("api/[controller]")]
     [ApiController]
     // MLS 10/16/23 Temporarily remove call to this
-    //[Authorize]
+    [Authorize]
     public class ItemsController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Utilities/Utilities.cs
+++ b/Utilities/Utilities.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿#define Use_Azure_Blob_Storage
+using System.IO;
 using BackSide.Models;
 using System.Text;
 using System.Drawing;
@@ -12,7 +13,7 @@ namespace BackSide.Utilities
     {
         public readonly string _baseImageDirectory;
         private readonly IConfiguration _configuration;
-#if (Use_Azure_Blob_Storage == true)
+#if Use_Azure_Blob_Storage
         private readonly BlobStorageService _blobStorageService;
         public FileStorageService(IConfiguration configuration,
                                     BlobStorageService blobStorageService)
@@ -34,7 +35,7 @@ namespace BackSide.Utilities
             // return the image in "imagename" as a base64 encoded string
             string base64String;
             
-#if (Use_Azure_Blob_Storage != true)
+#if Use_Azure_Blob_Storage
             base64String = GetImageFromHardDriveAsBase64(imageDirectory, imageName);
 #else
             base64String = await _blobStorageService.GetImageFromAzureBlobStorageAsBase64Async(imageDirectory, imageName);
@@ -53,7 +54,7 @@ namespace BackSide.Utilities
                 // this logic strips off the stuff after the :
                 // int len = formFile.FileName.IndexOf(":");
                 // string fileName = formFile.FileName.Substring(0,len);
-#if (Use_Azure_Blob_Storage != true)
+#if Use_Azure_Blob_Storage
                 SaveImageToHardDrive(image, imageDirectory, fileName);
 #else
                 _blobStorageService.SaveImageToAzureBlobStorage(image, imageDirectory, fileName);

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -4,6 +4,7 @@
     "Domain": "michellesimone.onmicrosoft.com",
     "TenantId": "77937645-4237-487f-9b47-68fa8ccc065e",
     "ClientId": "bec404a1-7783-4501-a090-2e3f885a05ff",
+    "identifierUris": "api://bec404a1-7783-4501-a090-2e3f885a05ff",
     "Scopes": {
       "Read": [ "User.Read", "User.ReadWrite" ],
       "Write": [ "User.ReadWrite" ]
@@ -15,7 +16,7 @@
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Warning",
       "Microsoft.AspNetCore": "Warning"
     }
   },


### PR DESCRIPTION
2) Reinstated call to AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd")); Rather than use the App Service's Built-In authentication which points to the same application registrations claims (tenant, clientid, etc) as my configuration settings under AzureAd. 

3) re-instated [Authorize] to the item and image controllers